### PR TITLE
fallback and error logging if running pgina as admin without domain p…

### DIFF
--- a/Plugins/LocalMachine/LocalAccount.cs
+++ b/Plugins/LocalMachine/LocalAccount.cs
@@ -863,7 +863,7 @@ namespace pGina.Plugin.LocalMachine
             catch
             {
                 // fallback for machine running pgina as local/machine admin and have groups from a domain.
-                // Failed to process gateway for bastopicus message: Unable to sync users local group membership: System.Runtime.InteropServices.COMException (0x80070035): The network path was not found.
+                // Failed to process gateway for ******* message: Unable to sync users local group membership: System.Runtime.InteropServices.COMException (0x80070035): The network path was not found.
                 sResult = user.GetGroups();
             }
 


### PR DESCRIPTION
fallback and error logging if running pgina as admin without domain privelages.

I was runnig pgina as administrator and my pc is part of a windows domain.
when localmachines try's to get information of that group i did get an error.
my administrator user has no rights on the domain, so quering the localgroups with members of the domain did give errors.
I now catch the error(s) and go to the next group.