### PR TITLE
Fix to load default settings on plugin load instead of conf screen

### DIFF
--- a/Plugins/LdapPlugin/Ldap/Plugin.cs
+++ b/Plugins/LdapPlugin/Ldap/Plugin.cs
@@ -44,6 +44,9 @@ namespace pGina.Plugin.Ldap
 
         public LdapPlugin()
         {
+            // Initialize settings during the plugin load
+            dynamic settings = Settings.Store;
+            
             using(Process me = Process.GetCurrentProcess())
             {
                 m_logger.DebugFormat("LDAP Plugin initialized on {0} in PID: {1} Session: {2}", Environment.MachineName, me.Id, me.SessionId);

--- a/Plugins/LocalMachine/PluginImpl.cs
+++ b/Plugins/LocalMachine/PluginImpl.cs
@@ -62,6 +62,9 @@ namespace pGina.Plugin.LocalMachine
 
         public PluginImpl()
         {
+            // Initialize settings during the plugin load
+            dynamic settings = Settings.Store;
+            
             using(Process me = Process.GetCurrentProcess())
             {
                 m_logger.DebugFormat("Plugin initialized on {0} in PID: {1} Session: {2}", Environment.MachineName, me.Id, me.SessionId);


### PR DESCRIPTION
During Silent install and automated configuration, the LDAP and Local Machine plugin causes an error because the registry keys are not created on plugin load.   Registry keys are only created by poping up the conf screen.  That's a problem with silent/automated scripts used to configure pgina.

That fix load the setting store onload...