### PR TITLE
Fixes mixed-content issues on pGina site by flipping http->https

### DIFF
--- a/develop.html
+++ b/develop.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html" class="active">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html" class="active">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -116,7 +116,7 @@
 	<div class="contentarea">
 <p>Follow this instructions</p>
 
-<p><a href="http://mutonufoai.github.io/pgina/documentation/core/plugins.html">URL</a></p>
+<p><a href="https://mutonufoai.github.io/pgina/documentation/core/plugins.html">URL</a></p>
 	</div>
 </div>
 
@@ -139,7 +139,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/develop/2014/01/09/01-create.html
+++ b/develop/2014/01/09/01-create.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -60,7 +60,7 @@
 	<div class="details">Posted by <a href="#"></a> on </div>	
 <p>Follow this instructions</p>
 
-<p><a href="http://mutonufoai.github.io/pgina/documentation/core/plugins.html">URL</a></p>
+<p><a href="https://mutonufoai.github.io/pgina/documentation/core/plugins.html">URL</a></p>
 	
 	<ul class="controls">
 		<li><a href="#" class="printerfriendly">Printer Friendly</a></li>
@@ -86,7 +86,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/develop/2014/01/09/02-compile.html
+++ b/develop/2014/01/09/02-compile.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -132,7 +132,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/documentation.html
+++ b/documentation.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -55,47 +55,47 @@
 <h2 id="user_documentation">User Documentation</h2>
 
 <ul>
-<li><a href="http://mutonufoai.github.io/pgina/documentation/user.html">pGina Users Guide</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/user.html">pGina Users Guide</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/login.html">Login Mask</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/login.html">Login Mask</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/uac.html">UAC</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/uac.html">UAC</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/changepwd.html">Change Password</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/changepwd.html">Change Password</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/rdp.html">Windows RDP connections</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/rdp.html">Windows RDP connections</a></li>
 
 <li>Plugins
 <ul>
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/email_auth.html">Email Authentication</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/email_auth.html">Email Authentication</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/multiemail.html">Multi Email Authentication</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/multiemail.html">Multi Email Authentication</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/httpauth.html">HttpAuth</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/httpauth.html">HttpAuth</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/kerberos.html">KRB5 Authentication</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/kerberos.html">KRB5 Authentication</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html">LDAP</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html">LDAP</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/mysql_logger.html">MySQL Logger</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/mysql_logger.html">MySQL Logger</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/mysql_auth.html">MySQL Authentication</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/mysql_auth.html">MySQL Authentication</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/pgsmb2.html">pgSMB2</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/pgsmb2.html">pgSMB2</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/radius.html">RADIUS Authentication &amp; Accounting</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/radius.html">RADIUS Authentication &amp; Accounting</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/scripting.html">scripting</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/scripting.html">scripting</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/session_limit.html">Session Limit</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/session_limit.html">Session Limit</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/single_user.html">Single User</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/single_user.html">Single User</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/sshauth.html">SSHAuth</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/sshauth.html">SSHAuth</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/plugins/username_mod.html">Modify Username</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/plugins/username_mod.html">Modify Username</a></li>
 </ul>
 </li>
 </ul>
@@ -103,9 +103,9 @@
 <h2 id="developer_docs">Developer Docs</h2>
 
 <ul>
-<li><a href="http://mutonufoai.github.io/pgina/documentation/core/plugins.html">Plugin Development</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/core/plugins.html">Plugin Development</a></li>
 
-<li><a href="http://mutonufoai.github.io/pgina/documentation/core/core.html">pGina Core Development</a></li>
+<li><a href="https://mutonufoai.github.io/pgina/documentation/core/core.html">pGina Core Development</a></li>
 </ul>
 
     

--- a/documentation/changepwd.html
+++ b/documentation/changepwd.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -64,23 +64,23 @@
 
 <p><b>Consider that a pGina user password change using Powershell, net user, Control Panel or any other method than CTRL+ALT+DEL will not inform pGina about that change.</b></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/changepwd_change_error.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/changepwd_change_error.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>… after submitting your credentials and a successfully detection of an password expired error. <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/changepwd_logon_ui.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/changepwd_logon_ui.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>… enter your new password <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/changepwd_success.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/changepwd_success.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>If everything went OK, than you’ll see a success message. In case of an error you’ll get an error message. <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/changepwd_ctrl_alt_del.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/changepwd_ctrl_alt_del.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>If you hit CTRL+ALT+DEL while logged in than you’ll get this kind of change password user interface. <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/changepwd_expire_warning.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/changepwd_expire_warning.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>If a password is close to expiration (5 days), a user is receiving a message telling him how long the password remains valid (LDAP plugin only). <br style='clear:both' /></p>
 

--- a/documentation/core/core.html
+++ b/documentation/core/core.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -62,7 +62,7 @@
 <hr /><h2 id='arch'>The pGina Architecture</h2>
 <p>pGina’s architecture is based on three main components: the credential provider/GINA, the pGina service, and the plugins. The image below shows the components and their relationship to eachother.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/core/pgina_components.png" alt="pGina components" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/core/pgina_components.png" alt="pGina components" /></p>
 
 <p>The Credential Provider or GINA augments or replaces the default Windows authentication functionality. In Windows Vista or later, this component is called a Credential Provider (CP), in prior versions of Windows, we it is a GINA. More details on each of these options is provided below, suffice it to say for now that this component plugs-in to the Windows authentication system and can configure parts of what is requested (username/ password), and what is displayed (logo, MOTD, etc.). In a standard login, the CP/GINA receives the user’s credentials and passes them along to the pGina Service via a named pipe.</p>
 

--- a/documentation/core/cp.html
+++ b/documentation/core/cp.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 

--- a/documentation/core/plugins.html
+++ b/documentation/core/plugins.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 

--- a/documentation/login.html
+++ b/documentation/login.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -52,33 +52,33 @@
 
 <h2 id="boot">Boot</h2>
 
-<p><img alt='pGina boot' src='http://mutonufoai.github.io/pgina/images/documentation/login_start.png' style='float:right' /></p>
+<p><img alt='pGina boot' src='https://mutonufoai.github.io/pgina/images/documentation/login_start.png' style='float:right' /></p>
 
 <p>Instead of showing a login mask as soon as possible, this fork will wait for the pGina service to came up until presenting a login screen. The reason is, without a running pGina service only local administrators are able to login! With that in mind I decided to show a message box until the pgina service is up and running, at least for one minute. <br style='clear:both' /></p>
 
-<p><img alt='pGina service failed' src='http://mutonufoai.github.io/pgina/images/documentation/login_start_failed.png' style='float:left' /></p>
+<p><img alt='pGina service failed' src='https://mutonufoai.github.io/pgina/images/documentation/login_start_failed.png' style='float:left' /></p>
 
 <p>If a minute has past and the pGina service is still down the login mask is shown, but with an exclamation mark logo. There can be a lot of reasons, like a slow machine, AV scanner, …. <br style='clear:both' /></p>
 
 <p><span style='float:right'>
 As soon as the pGina service is up the logo is shown, and thats the normal case.
-<img alt='pGina boot' src='http://mutonufoai.github.io/pgina/images/documentation/login_start_ok.png' style='vertical-align:text-top' /></span></p>
+<img alt='pGina boot' src='https://mutonufoai.github.io/pgina/images/documentation/login_start_ok.png' style='vertical-align:text-top' /></span></p>
 
 <p><br style='clear:both' /></p>
 
 <h2 id="login">Login</h2>
 
-<p>The login process is the same as always, but this fork will show another message box saying that the login is in process. <img alt='pGina boot' src='http://mutonufoai.github.io/pgina/images/documentation/login_running.png' style='float:left' /></p>
+<p>The login process is the same as always, but this fork will show another message box saying that the login is in process. <img alt='pGina boot' src='https://mutonufoai.github.io/pgina/images/documentation/login_running.png' style='float:left' /></p>
 
 <p><span style='float:right'>
 If you try to login while the pGina service is down you are limited to local administrators!
-<img alt='pGina service failed' src='http://mutonufoai.github.io/pgina/images/documentation/login_start_failed.png' style='vertical-align:text-top' /></span></p>
+<img alt='pGina service failed' src='https://mutonufoai.github.io/pgina/images/documentation/login_start_failed.png' style='vertical-align:text-top' /></span></p>
 
 <p><br style='clear:both' /></p>
 
 <p>If a user tries to login from such a stage he will receive an error message like</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/login_failed.png" alt="user login failed" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/login_failed.png" alt="user login failed" /></p>
 
 <h2 id="facts">Facts</h2>
 

--- a/documentation/plugins/email_auth.html
+++ b/documentation/plugins/email_auth.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -74,7 +74,7 @@
 
 <p>The configuration interface for the email authentication plugin is shown below.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/email_auth.png" alt="Email Authentication Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/email_auth.png" alt="Email Authentication Configuration" /></p>
 
 <p>Each configuration option is described below:</p>
 

--- a/documentation/plugins/httpauth.html
+++ b/documentation/plugins/httpauth.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 

--- a/documentation/plugins/kerberos.html
+++ b/documentation/plugins/kerberos.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 

--- a/documentation/plugins/ldap.html
+++ b/documentation/plugins/ldap.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -96,7 +96,7 @@
 
 <p>The configuration interface for the LDAP plugin is shown below.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_config.png" alt="LDAP configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_config.png" alt="LDAP configuration" /></p>
 
 <p>The configuration options are described below:</p>
 
@@ -124,7 +124,7 @@
 
 <h3 id="authentication_options">Authentication Options</h3>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_bind.png" alt="LDAP configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_bind.png" alt="LDAP configuration" /></p>
 
 <ul>
 <li><strong>Allow Empty Passwords</strong> – If this is checked, the plugin will attempt to authenticate the user even if the password is empty. When unchecked, it will fail to authenticate the user without attempting to bind to the LDAP server. Note that some servers may treat an empty password as an anonymous bind, so it is a good idea to leave this unchecked (the default).</li>
@@ -140,7 +140,7 @@
 
 <h4 id="attribute_converter_options">Attribute converter Options</h4>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_attrib.png" alt="LDAP attribute configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_attrib.png" alt="LDAP attribute configuration" /></p>
 
 <p><strong>Windows</strong> – The pGina internal attribute name</p>
 
@@ -168,7 +168,7 @@
 
 <h3 id="authorization_options">Authorization Options</h3>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_auth.png" alt="LDAP configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_auth.png" alt="LDAP configuration" /></p>
 
 <p>The authorization tab provides an interface for creating, removing, and deleting authorization rules. The rules are tested by the plugin in order and the first matching rule is applied. If none of the rules match, the default rule is applied. The default is configured using the radio buttons at the top of the tab interface.</p>
 
@@ -184,7 +184,7 @@
 
 <h3 id="gateway_options">Gateway Options</h3>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_gate.png" alt="LDAP configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_gate.png" alt="LDAP configuration" /></p>
 
 <p>The gateway tab provides options for creating and removing rules for adding local groups based on LDAP group membership. The rules are all applied in order from top to bottom. All rules are applied regardless of how many are a match for the user logging in.</p>
 
@@ -194,7 +194,7 @@
 
 <h3 id="change_password">Change Password</h3>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_password.png" alt="LDAP configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/ldap_plugin_password.png" alt="LDAP configuration" /></p>
 
 <p>The Change Password tab provides an interface for manipulating LDAP values in case of a password change event. The password change event is only triggered if the user is using CTRL+ALT+DEL or CTRL+ALT+END.</p>
 

--- a/documentation/plugins/local_machine.html
+++ b/documentation/plugins/local_machine.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -91,11 +91,11 @@
 <p>It’s possible to import user attributes from an LDAP <i>(only if the pgSMB2 plugin is’nt used)</i></p>
 
 <ul>
-<li>import the users full name by using the <a href='http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (Fullname)</li>
+<li>import the users full name by using the <a href='https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (Fullname)</li>
 
-<li>mount a home drive by using the <a href='http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (usri4_home_dir_drive and usri4_home_dir)</li>
+<li>mount a home drive by using the <a href='https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (usri4_home_dir_drive and usri4_home_dir)</li>
 
-<li>make use of a roaming profile by using the <a href='http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (usri4_profile) <br /><b>Requires enabled GPO setting</b> <i>&quot;Do not check for user ownership of Roaming Profile Folders&quot;</i></li>
+<li>make use of a roaming profile by using the <a href='https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (usri4_profile) <br /><b>Requires enabled GPO setting</b> <i>&quot;Do not check for user ownership of Roaming Profile Folders&quot;</i></li>
 </ul>
 
 <h3 id="notification">Notification</h3>
@@ -105,9 +105,9 @@
 <p>Following can be done too <i>(only if the pgSMB2 plugin is’nt used)</i><br /></p>
 
 <ul>
-<li>a login script can be started in the users context during log on. Its only possible by using the LDAP plugin <a href='http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (LoginScript)</li>
+<li>a login script can be started in the users context during log on. Its only possible by using the LDAP plugin <a href='https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (LoginScript)</li>
 
-<li>the profile size can be limitited. Its only possible by using the LDAP plugin <a href='http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (usri4_max_storage)</li>
+<li>the profile size can be limitited. Its only possible by using the LDAP plugin <a href='https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options'>Attribute converter</a> (usri4_max_storage)</li>
 </ul>
 
 <h3 id="change_password">Change Password</h3>
@@ -126,7 +126,7 @@
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/local_machine_config.png" alt="LocalMachine Plugin Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/local_machine_config.png" alt="LocalMachine Plugin Configuration" /></p>
 
 <h3 id="authentication">Authentication</h3>
 

--- a/documentation/plugins/multiemail.html
+++ b/documentation/plugins/multiemail.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -62,11 +62,11 @@
 
 <h2 id="how_it_works">How it Works</h2>
 
-<p>In fact it does exactly the same as the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/email_auth.html">Email Authentication Plugin</a>, except that you are able to add more than one server.</p>
+<p>In fact it does exactly the same as the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/email_auth.html">Email Authentication Plugin</a>, except that you are able to add more than one server.</p>
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/multiemail_config.png" alt="Multi Email Authentication Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/multiemail_config.png" alt="Multi Email Authentication Configuration" /></p>
 
 <ul>
 <li><strong>Protocol</strong> - The protocol for the server.</li>

--- a/documentation/plugins/mysql_auth.html
+++ b/documentation/plugins/mysql_auth.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -136,7 +136,7 @@
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_server.png" alt="MySQL Auth Server Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_server.png" alt="MySQL Auth Server Configuration" /></p>
 
 <ul>
 <li><strong>Host</strong> – The IP or fully-qualified hostname of the MySQL server.</li>
@@ -152,7 +152,7 @@
 <li><strong>MySQL Database</strong> – The database containing the account information table.</li>
 </ul>
 <h3>Database Schema Configuration</h3>
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_database.png" alt="MySQL Auth Database Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_database.png" alt="MySQL Auth Database Configuration" /></p>
 
 <p>Under the “Database Schema” tab, you can configure the column names and table names. Note that any table may include more columns than those listed here. The primary key for the user table may have the same name as the username column. If so, they are treated as a single column. Similarly for the primary key for the group table.</p>
 
@@ -162,7 +162,7 @@
 
 <p>The “Create Table…” button attempts to connect to the MySQL server and create the information tables.</p>
 <h3>Authentication Configuration</h3>
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_authentication.png" alt="MySQL Authentication Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_authentication.png" alt="MySQL Authentication Configuration" /></p>
 
 <p>The authorization tab provides an interface for creating, removing, and deleting authorization rules. The rules are tested by the plugin in order and the first matching rule is applied. If none of the rules match, the default rule is applied. The default is configured using the radio buttons at the top of the tab interface.</p>
 
@@ -172,7 +172,7 @@
 <li><strong>Deny when MySQL authentication fails</strong> - If this is checked, authorization fails when the MySQL plugin fails to authenticate the user in the authentication stage or the MySQL plugin does not execute in that stage.</li>
 </ul>
 <h3>Gateway Configuration</h3>
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_gateway.png" alt="MySQL Auth Gateway Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_auth_gateway.png" alt="MySQL Auth Gateway Configuration" /></p>
 
 <p>Under the “Gateway” tab you can configure a set of rules to be applied within the gateway stage. This allows you to add the user to local groups based on membership in MySQL groups.</p>
 

--- a/documentation/plugins/mysql_logger.html
+++ b/documentation/plugins/mysql_logger.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -66,7 +66,7 @@
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_logger_config.png" alt="MySQL Logger configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/mysql_logger_config.png" alt="MySQL Logger configuration" /></p>
 
 <h2 id="configuration_2">Configuration</h2>
 

--- a/documentation/plugins/pgsmb.html
+++ b/documentation/plugins/pgsmb.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -60,7 +60,7 @@
 
 <h2 id="how_it_works">How it Works</h2>
 
-<p><img alt='pgSMB how' src='http://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb_how.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pgSMB how' src='https://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb_how.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>The pgSMB plugin is a clone of the pGina 1.x pgFTP plugin. It’s purpose is to un/load compressed roaming profiles. Instead of using the windows internal roaming profile function, and upload a profile file by file, this plugin will compress the whole profile before uploading it and decompress it before loading it.</p>
 
@@ -164,7 +164,7 @@ Set-Acl C:\roaming $sd
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb_config.png" alt="pgSMB configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb_config.png" alt="pgSMB configuration" /></p>
 
 <h3 id="roaming_profile">Roaming Profile</h3>
 
@@ -180,19 +180,19 @@ Set-Acl C:\roaming $sd
 <li>
 <p><strong>The SMB share to connect</strong> – The path to the share which the plugin will try to connect to</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_SMBshare</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_SMBshare</p>
 </li>
 
 <li>
 <p><strong>Where to store the compressed Profile</strong> – This is the place where the compressed profile will be stored</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_profile</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_profile</p>
 </li>
 
 <li>
 <p><strong>The name and extension of the Profile</strong> – How do yoy want to name the compressed profile</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_Filename</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_Filename</p>
 </li>
 
 <li>
@@ -222,25 +222,25 @@ Set-Acl C:\roaming $sd
 <li>
 <p><strong>The user HomeDir</strong> – The path to the home share</p>
 
-<p>to be overridden by the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir</p>
+<p>to be overridden by the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir</p>
 </li>
 
 <li>
 <p><strong>The user HomedirDrive</strong> – The drive name of this share</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir_drive</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir_drive</p>
 </li>
 
 <li>
 <p><strong>Script Path</strong> – The script to run in the user context during a login</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> LoginScript</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> LoginScript</p>
 </li>
 
 <li>
 <p><strong>The user max storage space in kbytes</strong> – GPO setting to limit the profile size</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_max_storage</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_max_storage</p>
 </li>
 </ul>
 

--- a/documentation/plugins/pgsmb2.html
+++ b/documentation/plugins/pgsmb2.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -60,7 +60,7 @@
 
 <h2 id="how_it_works">How it Works</h2>
 
-<p><a href='http://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb2_diagram.png' target='_blank'><img alt='pgSMB2 how' src='http://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb2_diagram_preview.png' style='float:left; border:0px; padding-right:10px;' /></a></p>
+<p><a href='https://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb2_diagram.png' target='_blank'><img alt='pgSMB2 how' src='https://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb2_diagram_preview.png' style='float:left; border:0px; padding-right:10px;' /></a></p>
 
 <p>The pgSMB2 plugin is a clone of the pGina 1.x pgFTP plugin. It’s purpose is to implement a raoming profile stored in a compressed file on an SMB server.</p>
 
@@ -164,7 +164,7 @@ Set-Acl C:\roaming $sd
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb2_config.png" alt="pgSMB2 configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/pgsmb2_config.png" alt="pgSMB2 configuration" /></p>
 
 <h3 id="roaming_profile">Roaming Profile</h3>
 
@@ -180,19 +180,19 @@ Set-Acl C:\roaming $sd
 <li>
 <p><strong>The SMB share to connect</strong> – The path to the share which the plugin will try to connect to</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_SMBshare</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_SMBshare</p>
 </li>
 
 <li>
 <p><strong>Where to store the compressed Profile</strong> – This is the place where the compressed profile will be stored</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_profile</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_profile</p>
 </li>
 
 <li>
 <p><strong>The name and extension of the Profile</strong> – How do you want to name the compressed profile</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_Filename</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> pgSMB_Filename</p>
 </li>
 
 <li>
@@ -232,19 +232,19 @@ Set-Acl C:\roaming $sd
 <li>
 <p><strong>The user HomeDir</strong> – The path to the home share</p>
 
-<p>to be overridden by the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir</p>
+<p>to be overridden by the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir</p>
 </li>
 
 <li>
 <p><strong>The user HomedirDrive</strong> – The drive name of this share</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir_drive</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_home_dir_drive</p>
 </li>
 
 <li>
 <p><strong>Script Path</strong> – The script to run in the user context during a login</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> LoginScript</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> LoginScript</p>
 
 <p>make sure that a remote share is registered under Local intranet pages IE/Options/Security</p>
 </li>
@@ -254,7 +254,7 @@ Set-Acl C:\roaming $sd
 
 <p>A Profile that has reached its limit wont be uploaded, and an email is generated.</p>
 
-<p>to be overridden by <a href="http://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_max_storage</p>
+<p>to be overridden by <a href="https://mutonufoai.github.io/pgina/documentation/plugins/ldap.html#attribute_converter_options">Attribute converter</a> usri4_max_storage</p>
 </li>
 
 <li>

--- a/documentation/plugins/radius.html
+++ b/documentation/plugins/radius.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -78,7 +78,7 @@
 
 <p>The configuration interface for the RADIUS plugin is shown below.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/radius_config.png" alt="RADIUS Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/radius_config.png" alt="RADIUS Configuration" /></p>
 
 <p>Each configuration option is described below:</p>
 

--- a/documentation/plugins/scripting.html
+++ b/documentation/plugins/scripting.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -76,7 +76,7 @@
 
 <p>‘cmd.exe /c start ”” /i cmd.exe /k’ would not</p>
 
-<p>Always consider the <a href="http://mutonufoai.github.io/pgina/documentation/user.html#ordering_plugins">Plugin Order</a></p>
+<p>Always consider the <a href="https://mutonufoai.github.io/pgina/documentation/user.html#ordering_plugins">Plugin Order</a></p>
 
 <h2 id="configuration">Configuration</h2>
 
@@ -88,7 +88,7 @@
 <li>This plugin can’t Authenticate nor Authorize a user, another plugin has to successfully Authenticate or Authorize.</li>
 </ul>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/scripting_authe.png" alt="Scripting Plugin Authentication" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/scripting_authe.png" alt="Scripting Plugin Authentication" /></p>
 
 <ul>
 <li><strong>submit pwd</strong> – will add the users password into the command line (the macro is also needed)</li>
@@ -100,7 +100,7 @@
 
 <p>It is possible to run pograms in context of the SYSTEM and the USER, during logon and/or logoff events.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/scripting_notify.png" alt="Scripting Plugin Notification" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/scripting_notify.png" alt="Scripting Plugin Notification" /></p>
 
 <ul>
 <li><strong>submit pwd</strong> – will add the users password into the command line (the macro is also needed)</li>

--- a/documentation/plugins/session_limit.html
+++ b/documentation/plugins/session_limit.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -66,7 +66,7 @@
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/session_limit_config.png" alt="Session Limit Config" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/session_limit_config.png" alt="Session Limit Config" /></p>
 
 <ul>
 <li><strong>Global time limit</strong> – The number of minutes before users are logged off. If this is set to zero, it is the same as disabling this plugin.</li>

--- a/documentation/plugins/single_user.html
+++ b/documentation/plugins/single_user.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -68,7 +68,7 @@
 
 <h2 id="configuration">Configuration</h2>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/single_user_config.png" alt="Single User Plugin Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/single_user_config.png" alt="Single User Plugin Configuration" /></p>
 
 <ul>
 <li><strong>Username</strong> – The username of the local account.</li>
@@ -85,7 +85,7 @@
 <h2 id="consider_this">Consider this</h2>
 
 <p><span class='redbg'><b>
-By using this plugin pGina is unable to verify a user during logon as shown  <a href='http://mutonufoai.github.io/pgina/documentation/user.html#how_pgina_works'>here</a>. Pgina can’t detect a loggin off session from this user nor if this user is already logged in and tries to unlock the user. As you can see the Username Modification Plugin runs in stage 3 while the above checks are done in stage 2. Also plugins registered for Notification Events won’t work properly.</b></span></p>
+By using this plugin pGina is unable to verify a user during logon as shown  <a href='https://mutonufoai.github.io/pgina/documentation/user.html#how_pgina_works'>here</a>. Pgina can’t detect a loggin off session from this user nor if this user is already logged in and tries to unlock the user. As you can see the Username Modification Plugin runs in stage 3 while the above checks are done in stage 2. Also plugins registered for Notification Events won’t work properly.</b></span></p>
 
     
 		

--- a/documentation/plugins/sshauth.html
+++ b/documentation/plugins/sshauth.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -78,7 +78,7 @@
 
 <p>The configuration options for the SSHAuth plugin are described below:</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/sshauth_config.png" alt="SSHAuth configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/sshauth_config.png" alt="SSHAuth configuration" /></p>
 
 <ul>
 <li><strong>Host</strong> - SSH server. This field supports IP addresses or fully qualified domain names.</li>

--- a/documentation/plugins/username_mod.html
+++ b/documentation/plugins/username_mod.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -70,7 +70,7 @@
 
 <p>The configuration interface for the username modification plugin is shown below.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/plugins/username_mod.png" alt="Username Modification Configuration" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/plugins/username_mod.png" alt="Username Modification Configuration" /></p>
 
 <p>When adding a new rule, you’ll be faced with the following options:</p>
 
@@ -147,7 +147,7 @@
 <h2 id="consider_this">Consider this</h2>
 
 <p><span class='redbg'><b>
-By using this plugin pGina is unable to verify a user during logon as shown  <a href='http://mutonufoai.github.io/pgina/documentation/user.html#how_pgina_works'>here</a>. Pgina can’t detect a loggin off session from this user nor if this user is already logged in and tries to unlock the user. As you can see the Username Modification Plugin runs in stage 3 while the above checks are done in stage 2. Also plugins registered for Notification Events won’t work properly.</b></span></p>
+By using this plugin pGina is unable to verify a user during logon as shown  <a href='https://mutonufoai.github.io/pgina/documentation/user.html#how_pgina_works'>here</a>. Pgina can’t detect a loggin off session from this user nor if this user is already logged in and tries to unlock the user. As you can see the Username Modification Plugin runs in stage 3 while the above checks are done in stage 2. Also plugins registered for Notification Events won’t work properly.</b></span></p>
 
     
 		

--- a/documentation/rdp.html
+++ b/documentation/rdp.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -112,7 +112,7 @@ password 51:b:longbytestring
 
 <h2 id="rdp_from_a_pgina_client">RDP from a pgina client</h2>
 
-<p>You can’t use pgina to preauthenticate on another machine. Only Windows default password provider (“Use another account”) will do this. <img src="http://mutonufoai.github.io/pgina/images/documentation/rdp_remote_connection.png" alt="Windows RDP GUI" /></p>
+<p>You can’t use pgina to preauthenticate on another machine. Only Windows default password provider (“Use another account”) will do this. <img src="https://mutonufoai.github.io/pgina/images/documentation/rdp_remote_connection.png" alt="Windows RDP GUI" /></p>
 
 <h2 id="windows_10">Windows 10</h2>
 

--- a/documentation/uac.html
+++ b/documentation/uac.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -50,19 +50,19 @@
 			
 <h1 id="user_account_control">User Account Control</h1>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/uac_start.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/uac_start.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>The User Account Control is handled as you know it from Windows <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/uac_login.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/uac_login.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>You can use local or remote accounts with pGina. <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/uac_process.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/uac_process.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>While your request is beeing processed you’ll get a message box. The whole pGina plugin chain is called as long as this user is a pGina user, there is no diffence to a normal login. <br style='clear:both' /></p>
 
-<p><img alt='pGina UAC' src='http://mutonufoai.github.io/pgina/images/documentation/uac_failed.png' style='float:left; border:0px; padding-right:10px;' /></p>
+<p><img alt='pGina UAC' src='https://mutonufoai.github.io/pgina/images/documentation/uac_failed.png' style='float:left; border:0px; padding-right:10px;' /></p>
 
 <p>If there is an error you’ll get another message box telling you what went wrong. <br />In the case of this screenshot someone elevated a program by using runas. If another user is trying to elevate a program using the same administratively account (if a pGina user), than you’ll get this error. Local or Domain accounts won’t run in such a problem, because only pGina users are monitored. <br style='clear:both' /></p>
 

--- a/documentation/user.html
+++ b/documentation/user.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default_doc.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default_doc.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html" class="active">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -76,7 +76,7 @@
 
 <p>After installation, start the pGina configuration application. Verify that the pGina service is running and that the Credential Provider/GINA is installed and enabled.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/components_green_screen.png" alt="pgina Components Enabled" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/components_green_screen.png" alt="pgina Components Enabled" /></p>
 
 <p>pGina will not function properly unless these components are working. More information about the Credential Provider and pGina service is provied in the next section.</p>
 
@@ -88,23 +88,23 @@
 
 <p>The diagram below represents a high-level picture of a typical logon process.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pGina-logon-overview.png" alt="pGina logon diagram" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pGina-logon-overview.png" alt="pGina logon diagram" /></p>
 
-<p><span class='greenbg'>To distinguish between pGina and a nomal windows user accounts, every pGina user is marked with a user comment of<i>&quot;pGina created&quot;</i>. Only non existent (<a href='http://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html'>LocalMachine plugin</a>) and<i>&quot;pGina created&quot;</i>user accounts are touched by pGina, if that’s not the case then this particular account wont be altered by pGina. To go further, local non pGina users and Domain users dont run through the plugin chain!</span></p>
+<p><span class='greenbg'>To distinguish between pGina and a nomal windows user accounts, every pGina user is marked with a user comment of<i>&quot;pGina created&quot;</i>. Only non existent (<a href='https://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html'>LocalMachine plugin</a>) and<i>&quot;pGina created&quot;</i>user accounts are touched by pGina, if that’s not the case then this particular account wont be altered by pGina. To go further, local non pGina users and Domain users dont run through the plugin chain!</span></p>
 
 <p>The logon process proceeds as follows:</p>
 
 <ol>
 <li>The user enters their credentials at the pGina logon user interface. Note that this UI may be one of several options (called credential providers) presented to the user. For example, the user might be presented with several tiles, many of which are local accounts with only one being the pGina UI.</li>
 
-<li>The pGina credential provider (or GINA) passes the credentials to the pGina service. If the user is currently logging off a relogin is denied. If the user is not a pGina user than he is processed by WinAPI authentication procedures, and if a user was already authenticated he will be processed by the WinAPI as well. If nothing from above apply, than the service sends those credentials through the <a href="#plugins">plugin pipeline</a> described below. <strong>This stage potentially fails if you modified the username by using a plugin like <a href="http://mutonufoai.github.io/pgina/documentation/plugins/username_mod.html">Username Modification</a>!</strong></li>
+<li>The pGina credential provider (or GINA) passes the credentials to the pGina service. If the user is currently logging off a relogin is denied. If the user is not a pGina user than he is processed by WinAPI authentication procedures, and if a user was already authenticated he will be processed by the WinAPI as well. If nothing from above apply, than the service sends those credentials through the <a href="#plugins">plugin pipeline</a> described below. <strong>This stage potentially fails if you modified the username by using a plugin like <a href="https://mutonufoai.github.io/pgina/documentation/plugins/username_mod.html">Username Modification</a>!</strong></li>
 
 <li>After the credentials have been <a href="#plugins">processed by the plugins</a>, the pGina service sends a result (success/failure) along with a set of credentials (username/ password) back to the pGina CP. Note that these credentials may not be the same as those that were provided by the user. They may have been altered at some stage by one or more plugins.</li>
 
-<li>If the result returned from step three is success, the pGina credential provider passes the (possibly altered) credentials to Windows indicating a successful logon attempt. Note that pGina does not actually log the user on to the machine. It is the Windows OS itself that does that. This means that if a local account does not exist that matches the credentials, the logon will fail, even if the pGina plugins have registered success. Therefore, it is often the case that one of the plugins will be responsible for creating a local (often temporary) account. The plugin called “Local Machine” takes care of this in the Gateway stage. For details, see the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">documentation for the Local Machine plugin</a>.</li>
+<li>If the result returned from step three is success, the pGina credential provider passes the (possibly altered) credentials to Windows indicating a successful logon attempt. Note that pGina does not actually log the user on to the machine. It is the Windows OS itself that does that. This means that if a local account does not exist that matches the credentials, the logon will fail, even if the pGina plugins have registered success. Therefore, it is often the case that one of the plugins will be responsible for creating a local (often temporary) account. The plugin called “Local Machine” takes care of this in the Gateway stage. For details, see the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">documentation for the Local Machine plugin</a>.</li>
 </ol>
 
-<p>As indicated above, it is important to note that pGina does not actually log the user on to the computer. The Windows OS is still ultimately responsible for logging the user on to the machine and possibly creating a profile for the user. pGina’s job is to authenticate and authorize the user, and perform any other pre-logon actions that may be needed. This means that in order for a logon to be successful, a local account must exist that matches the credentails returned by the pGina CP (Credential Provider). In a typical case, pGina would be configured to create the local account prior to logon, and possibly delete that account after logoff (see the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine plugin</a>).</p>
+<p>As indicated above, it is important to note that pGina does not actually log the user on to the computer. The Windows OS is still ultimately responsible for logging the user on to the machine and possibly creating a profile for the user. pGina’s job is to authenticate and authorize the user, and perform any other pre-logon actions that may be needed. This means that in order for a logon to be successful, a local account must exist that matches the credentails returned by the pGina CP (Credential Provider). In a typical case, pGina would be configured to create the local account prior to logon, and possibly delete that account after logoff (see the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine plugin</a>).</p>
 
 <p>To explain the logon in a different way </p>
 
@@ -150,7 +150,7 @@
 
 <p>pGina consists of two main components: the Credential Provider (or GINA), and the pGina service (which manages the plugins).</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pgina_components.png" alt="pGina components" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pgina_components.png" alt="pGina components" /></p>
 
 <p>The CP augments or replaces the default Windows authentication user interface. It plugs-in to the Windows system and can configure the UI that is displayed at login time (or during unlock, UAC control, etc.). The pGina CP, however, does very little on its own. It simply receives the user’s credentials and passes them along to the pGina service via a named pipe, and then waits for a response from the service. User authentication/authorization is instead managed by the plugins that run within the pGina service.</p>
 
@@ -158,7 +158,7 @@
 
 <h3 id="configuration">Configuration</h3>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_global.png" alt="pGina stages" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_global.png" alt="pGina stages" /></p>
 
 <ul>
 <li><strong>Tile Image</strong> - You can set your own Image here. 200x200 BMP</li>
@@ -210,7 +210,7 @@
 
 <p>pGina manages the logon process by delegating the work to a set of zero or more plugins. Plugins have the job of deciding whether or not the user is who she says she is (authentication), whether the user should be granted access (authorization), and taking other login-time actions. The process involves a pipeline consisting of three main stages as illustrated in the following diagram.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pgina_stages.png" alt="pGina stages" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pgina_stages.png" alt="pGina stages" /></p>
 
 <p>Each stage involves zero or more plugins, and a given plugin may be involved in multiple stages. After the user provides his/her credentials, pGina passes through the three stages one at a time, in the order shown above. Each stage may succeed or fail depending on the results of the plugins involved. The purpose of each stage is summarized below.</p>
 
@@ -247,7 +247,7 @@
 
 <p>During the execution of the above pipeline, pGina maintains some information about the user. This includes user-name, password, group membership and other information. This information can be altered by plugins during the pipeline, and/or used by plugins to modify the state of the machine. For example, plugins may add or remove groups, alter the username or password, or a plugin might attempt to create a local account using this information. This means that the order that the plugins execute within each stage of the pipeline is important (see below), and different orders may produce different results. One must be careful to configure your plugins in the order that makes sense for your setup. The final values of username/password/domain are passed along to Windows to complete the logon process.</p>
 
-<p>In a typical setup one wants to make sure that a local account exists or is created at the end of the pipeline. To do so, one should configure the LocalMachine plugin so that it executes last in the Gateway stage. It is the Gateway stage of the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine</a> plugin that creates (if necessary) local accounts. If the <a href="http://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine</a> plugin executes earlier, it may miss important information for the local account (such as group membership).</p>
+<p>In a typical setup one wants to make sure that a local account exists or is created at the end of the pipeline. To do so, one should configure the LocalMachine plugin so that it executes last in the Gateway stage. It is the Gateway stage of the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine</a> plugin that creates (if necessary) local accounts. If the <a href="https://mutonufoai.github.io/pgina/documentation/plugins/local_machine.html">LocalMachine</a> plugin executes earlier, it may miss important information for the local account (such as group membership).</p>
 
 <h3 id="event_notifications">Event Notifications</h3>
 
@@ -263,19 +263,19 @@
 
 <p>To configure a plugin, double click on it or select it and click on “Configure..”. The plugin’s configuration dialog will appear. The options are plugin specific, and you should refer to the documentation for each plugin for details about configuration of an individual plugin.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_plugins.png" alt="pGina stages" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_plugins.png" alt="pGina stages" /></p>
 
 <h2 id="ordering_plugins">Ordering Plugins</h2>
 
 <p>Under the “Plugin Order” tab, you can determine the order that each plugin is invoked. There is a list for each pGina stage, and you can re-order the plugins within each list.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_pluginorder.png" alt="pGina stages" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_pluginorder.png" alt="pGina stages" /></p>
 
 <h2 id="credential_provider_filter">Credential Provider Filter</h2>
 
 <p>Credential Providers can be filtered for the Logon, Unlock, Change Password and Cred UI screens. Installed Providers are listed under <i>Credential Provider</i>. If you want pGina to be the only Credential Provider available on the logon screen than you need to enable the <i>Logon</i> checkbox for the <i>PasswordProvider</i>.</p>
 
-<p><img src="http://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_providerfilter.png" alt="pGina stages" /></p>
+<p><img src="https://mutonufoai.github.io/pgina/images/documentation/pgina_configuration_providerfilter.png" alt="pGina stages" /></p>
 
 <h2 id="logging">Logging</h2>
 

--- a/download.html
+++ b/download.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html" class="active">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html" class="active">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -215,7 +215,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/downloads/2011/08/25/License.html
+++ b/downloads/2011/08/25/License.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -102,7 +102,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/downloads/2012/11/14/3.1.6.2-download.html
+++ b/downloads/2012/11/14/3.1.6.2-download.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -88,7 +88,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/downloads/2013/12/02/3.2.0.0-download.html
+++ b/downloads/2013/12/02/3.2.0.0-download.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -88,7 +88,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/downloads/2014/12/16/3.2.4.1-download.html
+++ b/downloads/2014/12/16/3.2.4.1-download.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -88,7 +88,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/downloads/2017/02/03/3.9.9.7-download.html
+++ b/downloads/2017/02/03/3.9.9.7-download.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -88,7 +88,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/faq.html
+++ b/faq.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html" class="active">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html" class="active">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -163,7 +163,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/faq/2014/01/09/01.html
+++ b/faq/2014/01/09/01.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -86,7 +86,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/faq/2014/01/09/07.html
+++ b/faq/2014/01/09/07.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -112,7 +112,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/faq/2014/01/09/08.html
+++ b/faq/2014/01/09/08.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -96,7 +96,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/faq/2014/01/09/09.html
+++ b/faq/2014/01/09/09.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -98,7 +98,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html" class="active">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html" class="active">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -51,7 +51,7 @@
 			<div class="contentarea">
 				<!-- Normal content area start -->
 
-				<img src="http://mutonufoai.github.io/pgina/images/pginalogo_simple.png" class="left" alt="pGina logo" />
+				<img src="https://mutonufoai.github.io/pgina/images/pginalogo_simple.png" class="left" alt="pGina logo" />
 				pGina is a pluggable Open Source GINA and CredentialProvider 
 				replacement.
 				<br>This allows for alternate methods of interactive user 
@@ -68,7 +68,7 @@
         <br>pGina is the solution.
         
         <p><br><h3><strong>the fork</strong></h3>
-        <br><img src="http://mutonufoai.github.io/pgina/images/fork.png" class="left" alt="fork logo" />
+        <br><img src="https://mutonufoai.github.io/pgina/images/fork.png" class="left" alt="fork logo" />
         The fork was created first simply because it's the way to contribute on Github.
         <br>Later on due to time pressure and a refused pull request.
         <br>Now the code differs so much that it's hard to merge it back again, nevertheless I still hope that someday...
@@ -584,7 +584,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/news/2012/11/14/3.1.6.0-forked.html
+++ b/news/2012/11/14/3.1.6.0-forked.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -84,7 +84,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/news/2013/02/27/pgSMB-denied.html
+++ b/news/2013/02/27/pgSMB-denied.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -84,7 +84,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/news/2013/10/04/3.1.6.2-release.html
+++ b/news/2013/10/04/3.1.6.2-release.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -98,7 +98,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/news/2013/12/02/3.2.0.0-release.html
+++ b/news/2013/12/02/3.2.0.0-release.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -136,7 +136,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/news/2014/12/16/3.4.1.0-release.html
+++ b/news/2014/12/16/3.4.1.0-release.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -172,7 +172,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/news/2017/02/15/3.9.9.7-release.html
+++ b/news/2017/02/15/3.9.9.7-release.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -164,7 +164,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/support.html
+++ b/support.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html" class="active">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html" class="active">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -101,7 +101,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/support/2014/01/09/bug.html
+++ b/support/2014/01/09/bug.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -96,7 +96,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/support/2014/01/09/contact.html
+++ b/support/2014/01/09/contact.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -84,7 +84,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/thanks.html
+++ b/thanks.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html" class="active">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html" class="active">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -80,7 +80,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>

--- a/thanks/2014/01/09/thx.html
+++ b/thanks/2014/01/09/thx.html
@@ -12,7 +12,7 @@
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 
-<link rel="stylesheet" type="text/css" href="http://mutonufoai.github.io/pgina/default.css" />
+<link rel="stylesheet" type="text/css" href="https://mutonufoai.github.io/pgina/default.css" />
 
 </head>
 <body>
@@ -24,20 +24,20 @@
 			<h1>pGina fork</h1>
 			<h2>Open Source Windows Authentication</h2>
 		</div>
-		<div id="logo"><a href="http://mutonufoai.github.io/pgina/index.html"><img src="http://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
+		<div id="logo"><a href="https://mutonufoai.github.io/pgina/index.html"><img src="https://mutonufoai.github.io/pgina/images/pginalogo.png" /></a></div>
 	</div>
 
 	
 	<div id="menu">
 		<!-- HINT: Set the class of any menu link below to "active" to make it appear active -->
 		<ul>
-			<li><a href="http://mutonufoai.github.io/pgina/index.html">Home</a></li>
-			<li><a href="http://mutonufoai.github.io/pgina/download.html">Download</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/support.html">Support</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
-      <li><a href="http://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/index.html">Home</a></li>
+			<li><a href="https://mutonufoai.github.io/pgina/download.html">Download</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/support.html">Support</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/develop.html">Develop</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/faq.html">FAQ</a></li>
+      <li><a href="https://mutonufoai.github.io/pgina/thanks.html">Thanks</a></li>
 		</ul>
 	</div>
 
@@ -84,7 +84,7 @@
 				<h4>Additional Resources</h4>
 				<div class="contentarea">
 					<ul class="linklist">
-            <li><a href="http://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
+            <li><a href="https://mutonufoai.github.io/pgina/documentation.html">Documentation</a></li>
 						<li><a href="https://github.com/MutonUfoAI/pgina/" target="_blank">pGina fork on Github</a></li>
 						<li><a href="http://pgina.org/" target="_blank">pGina</a></li>
 					</ul>


### PR DESCRIPTION
[GitHub enforces HTTPS for GitHub Pages since 2016](https://blog.github.com/2016-06-08-https-for-github-pages/).  Other tools like HTTPS Everywhere automatically enable this for old repositories. This breaks CSS for the entire site:

![mutonufoai github io_pgina_](https://user-images.githubusercontent.com/246847/50555464-9c0d3c00-0d18-11e9-910e-7fa59e2584b3.png)

This PR does a find-replace on all the pages to replace `http://mutonufoai.github.io` with `https://mutonufoai.github.io`.