### PR TITLE
Fixed validation of server certificates

### DIFF
--- a/Plugins/LdapPlugin/Ldap/LdapServer.cs
+++ b/Plugins/LdapPlugin/Ldap/LdapServer.cs
@@ -268,7 +268,7 @@ namespace pGina.Plugin.Ldap
             {
                 try
                 {
-                    X509Store certStore = new X509Store(StoreLocation.LocalMachine);
+                    X509Store certStore = new X509Store(StoreName.Root, StoreLocation.LocalMachine);
                     certStore.Open(OpenFlags.ReadOnly);
                     if (certStore.Certificates.Contains(cert))
                         return true;


### PR DESCRIPTION
On Windows 10 (for certain), instantiating an X509Store defaults to the MY (i.e. user) certificate store. For new users, this is empty. System-wide CA certificates are held in the Root store. This constructor sets this explicitly. Doing so allows the server SSL certificate to be validated against the system CA cache.